### PR TITLE
fixes potential integer overflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/cmd/base_flags.go
+++ b/cmd/base_flags.go
@@ -402,7 +402,7 @@ func (i *int32Value) ValueType() string {
 }
 
 func (i *int32Value) Set(s string) error {
-	v, err := strconv.ParseInt(s, 0, 64)
+	v, err := strconv.ParseInt(s, 10, 32)
 	if err != nil {
 		return err
 	}
@@ -499,7 +499,7 @@ type UintVar struct {
 func (f *FlagSet) UintVar(i *UintVar) {
 	initial := i.Default
 	if v, exist := os.LookupEnv(i.EnvVar); exist {
-		if i, err := strconv.ParseUint(v, 0, 64); err == nil {
+		if i, err := strconv.ParseUint(v, 10, 32); err == nil {
 			initial = uint(i)
 		}
 	}


### PR DESCRIPTION
Fixes an integer overflow problem by forcing `strconv.Uint` to only parse 32 bits in base 10. Also fixed a bug where we parse base 0 instead of base 10. Closes https://github.com/mxplusb/pleiades/security/code-scanning/2 and https://github.com/mxplusb/pleiades/security/code-scanning/1