### PR TITLE
RFC: Service graph

### DIFF
--- a/docs/rfcs/00000000_template.md
+++ b/docs/rfcs/00000000_template.md
@@ -1,0 +1,46 @@
+- Feature Name:
+- Status: draft/in-progress/completed/rejected/obsolete/postponed
+- Start Date: YYYY-MM-DD
+- Authors:
+- RFC PR: (PR # after acceptance of initial draft)
+- Issue: (one or more # from the issue tracker)
+
+**Remember, you can submit a PR with your RFC before the text is
+complete. Refer to the [README](README.md#rfc-process) for details.**
+
+**Remember, you can either fill in this template from scratch, for
+example if you prefer working from a blank slate, or you can follow
+the writing prompts in the [GUIDE](GUIDE.md). In any case, please ensure
+at the end that you have all relevant topics from the guide covered in
+your prose.**
+
+# Summary
+
+- What is being proposed
+- Why (short reason)
+- How (short plan)
+- Impact
+
+# Motivation
+
+Audience: PMs, end-users, Pleiades contributors.
+
+# Technical design
+
+Audience: Pleiades contributors, expert users.
+
+## Drawbacks
+
+...
+
+## Rationale and Alternatives
+
+...
+
+# Explain it to folk outside your team
+
+Audience: PMs, doc writers, end-users, Pleiades contributors in other areas of the project.
+
+# Unresolved questions
+
+Audience: all participants to the RFC review.

--- a/docs/rfcs/20230609_service_graph.md
+++ b/docs/rfcs/20230609_service_graph.md
@@ -1,0 +1,176 @@
+- Feature Name: service_graph
+- Status: draft
+- Start Date: 2023-06-09
+- Authors: @mxplusb
+- RFC PR: (PR # after acceptance of initial draft)
+- Issue: #18
+
+# Summary
+
+This proposal recommends an internal service graph be created and introduced into the Pleiades runtime layer. This is needed because the internal app framework currently in use, fx, has reached the end of its capabilities and suitability for Pleiades. The internal service graph would be a DAG implementation in the configuration package designed to make it easy to configure, resolve, and run internal service interdependencies. The impact will affect the entire runtime layer because it will restructure and remap how service connectedness works. This implementation should allow Pleiades to start to grow its internals at different paces without breaking any isolation requirements.
+
+# Motivation
+
+**Audience:** Pleiades Contributors and System Operators
+
+The primary motivation behind using a service graph to resolve service dependencies is to address the core architectural needs of Pleiades. The internal structure of a Pleiades node is highly complex and relational, not hierarchial. The complexity of this internal structure is handled through an internal message bus, so relationships are modeled through events, but it still leaves a lot of challenges when dealing with booting a node, safely shutting down a node, and restarting failed processed remotely. By implementing a service graph, Pleiades will be able to scale its internal process architecture to meet any size or complexity needs without creating unmaintainable architectures.
+
+# Technical design
+
+**Audience:** Pleiades Contributors
+
+The technical implementation of the service graph is a directed, acyclic graph (DAG). DAGs are used everywhere, and are the underlying models for workflow models in nearly every workflow engine. DAGs can also be used to represent dependency trees and model dependency injection requirements, which is the use case for Pleiades. This diagram is an example of some process interdependencies represented as a DAG.
+
+```mermaid
+graph
+A[nats] --> B[SEH]
+A --> C[REH]
+A --> D[NHG]
+D --> E[NodeHost]
+C --> E
+F[serf] --> D
+F --> B
+G[config] --> F
+E --> H[KvStore]
+E --> I[TM]
+F --> J[http]
+A --> J
+H --> J
+E --> J
+I --> J
+```
+
+At the time of the proposal, this is what the current state of an app framework looks like:
+
+```go
+app := fx.New(
+    fx.Provide(func() *viper.Viper {
+        return config
+    }),
+    fx.Provide(func() dconfig.NodeHostConfig {
+        nhc := dconfig.NodeHostConfig{
+            DeploymentID:   config.GetUint64("server.host.deployment-id"),
+            WALDir:         logDir,
+            NodeHostDir:    dataDir,
+            RTTMillisecond: config.GetUint64("server.host.rtt"),
+            ListenAddress:  nodeAddr,
+            RaftAddress:    raftAddr,
+            EnableMetrics:  true,
+            NotifyCommit:   config.GetBool("server.host.notifyCommit"),
+        }
+
+        certFile := config.GetString("tls.cert-file")
+        keyFile := config.GetString("tls.key-file")
+        caFile := config.GetString("tls.ca-cert-file")
+
+        if certFile != "" && keyFile != "" && caFile != "" {
+            nhc.MutualTLS = true
+            nhc.CAFile = caFile
+            nhc.CertFile = certFile
+            nhc.KeyFile = keyFile
+        }
+        return nhc
+    }),
+    fx.Provide(func() zerolog.Logger { // the generalized logger
+        return logger
+    }),
+    fx.WithLogger(func() fxevent.Logger { // this provides the fx logger, not the general logger
+        return zerologAdapter{logger}
+    }),
+    fx.Provide(eventing.NewServer),
+    fx.Provide(server.NewHttpServeMux),
+    fx.Provide(server.NewNodeHost),
+    fx.Provide(server.NewHttpServer),
+    fx.Provide(eventing.NewPubSubClient),
+    fx.Provide(eventing.NewStreamClient),
+    fx.Provide(eventing.NewLifecycleManager),
+    fx.Provide(kvstore.NewBboltStoreManager),
+    fx.Provide(server.AsRoute(kvstore.NewKvstoreBboltConnectAdapter)),
+    fx.Provide(server.AsRoute(kvstore.NewKvstoreTransactionConnectAdapter)),
+    fx.Provide(raft.NewHost),
+    fx.Provide(server.AsRoute(raft.NewRaftHostConnectAdapter)),
+    fx.Provide(server.AsRoute(shard.NewRaftShardConnectAdapter)),
+    fx.Provide(shard.NewManager),
+    fx.Provide(transactions.NewManager)
+    fx.Invoke(eventing.NewLifecycleManager),
+    fx.Invoke(server.NewHttpServer),
+)
+
+if err := app.Start(ctx); err != nil {
+    logger.Fatal().Err(err).Msg("can't start services")
+}
+```
+
+Because Pleiades currently uses [`fx`](https://github.com/uber-go/fx) for the service dependency mappings, it's led to a mess of logic that's been interspersed throughout the processes and singletons. `fx` only handles lazy initialization for the constructors, which means that services can't easily or independently be started to properly resolve the dependencies. The underlying dependency injection framework, [`dig`](https://pkg.go.dev/go.uber.org/dig), for `fx` is useful, but it's also missing some core features, such as booting or shutting down a system. The service graph design aims to solve this problem and be scalable for many years.
+
+Initially, the underlying DAG will be provided by the [`dag`](https://pkg.go.dev/github.com/heimdalr/dag) library. While introducing more dependencies is risky, the benefits of using a tried and tested DAG outweigh the supply chain concerns. The service graph functionality will be built on top `dag`, with some useful features from `dig` being included.
+
+The service graph will meet these core requirements:
+1. Resolving a service and its dependencies is independent of it's lifecycle
+2. Starting a service will resolve and start all of its dependent services
+3. Stopping a service will resolve may shut down all of its parent services
+4. Service configurations must be functionally separate from the service
+5. Services can implement an interface to participate in the start/stop lifecycle
+6. The service graph will implement a lifecycle
+
+To support lifecycle requirements, the service graph should contain these lifecycle definitions:
+* Stopped
+* Starting
+* Started
+* Stopping
+
+The lifecycle state transitions will look like this:
+
+```mermaid
+graph LR
+A[stopped] --> B[starting] --> C[started] --> D[stopping]
+B --> A
+B --> D
+C --> A
+D --> A
+A --> C
+```
+
+This set of state transitions will allow for implementing services to be truthful when interrogated, but also keep the design flexible enough to be representative of the state. To support the service states, an `IHostedService` interface must be created, and is defined like so:
+
+```go
+type IHostedService interface {
+	dag.IDInterface
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+	LifecycleState() LifecycleState
+}
+```
+
+`IHostedService` embeds `dag.IDInterface` so services can define their own service identifier - this also makes it easier for debugging. The service graph should contain these core methods:
+* `AddOption[T ~struct](opt T) error`
+* `RemoveOption[T ~struct](opt T) error`
+* `RegisterService[T IHostedService](svc T) error`
+* `UnregisterService[T IHostedService](svc T) error`
+* `ResolveService[T IHostedService](id string) T`
+* `StartService(id string) error`
+* `StopService(id string) error`
+* `Boot() error`
+* `Shutdown() error`
+
+These methods provide the core functionality required for scalable service management across the code base, and don't necessarily require developers to have to care too much about the internals. A key functional requirement is the ability to resolve a service, regardless of its state. While dependency injection is only targeted for service graph members, this functionality would allow for dependency injection outside the service graph at a later time.
+
+## Drawbacks
+
+The first drawback is the need for this to exist. Several frameworks were tried, but none solved the problem effectively. This is also an incredibly complex solution for a (currently) small problem, and is generally overkill for the current state of Pleiades. It also introduces systemic complexity, a third party library, and increases the maintenance load of contributors.
+
+## Rationale and Alternatives
+
+The current spaghetti code problem is only small because development can't safely progress. There are a couple different ways to solve this problem, through `fx` and `dig`, but none really solve the problem the way Pleiades needs. This problem will only continue to grow in scale as Pleiades continues to evolve, and this approach, while heavy handed, will prevent this problem from occurring in the future.
+
+# Explain it to folk outside your team
+
+**Audience:** PMs, doc writers, end-users, Pleiades contributors in other areas of the project
+
+This change enables better lifecycle management for Pleiades' internal services, enables a better isolation between dependencies, and will allow the code base to continue to evolve without increasing development overhead. Designing and integrating new services into Pleiades will be very straightforward, and should drastically decrease SDLC cycle times for those work streams.
+
+# Unresolved questions
+
+Audience: all participants to the RFC review.
+
+Is there a more efficient, less complex solution to this problem?

--- a/docs/rfcs/20230609_service_graph.md
+++ b/docs/rfcs/20230609_service_graph.md
@@ -2,7 +2,7 @@
 - Status: draft
 - Start Date: 2023-06-09
 - Authors: @mxplusb
-- RFC PR: (PR # after acceptance of initial draft)
+- RFC PR: #19
 - Issue: #18
 
 # Summary

--- a/docs/rfcs/GUIDE.md
+++ b/docs/rfcs/GUIDE.md
@@ -1,0 +1,219 @@
+**Note: Be sure to also look at the [README](README.md) for more general guidance on writing RFCs.**
+
+# Summary
+
+One paragraph explanation of the proposed change.
+
+Suggested contents:
+- What is being proposed
+- Why (short reason)
+- How (short plan)
+- Impact
+
+# Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+Is there a PM in this product area already? Does the PM know of user
+stories that relate to the proposed work? Can we list these user
+stories here? (Specific customer names need not be included, for
+confidentiality, but it is still useful to describe their use cases.)
+
+# Technical design
+
+This is the technical portion of the RFC. Explain the design in sufficient detail.
+
+Important writing prompts follow. You do not need to answer them in
+this particular order, but we wish to find answers to them throughout
+your prose.
+
+Some of these prompts may not be relevant to your RFC; in which case
+you can spell out “this change does not affect ...” or answer “N/A”
+(not applicable) next to the question.
+
+- Questions about the change:
+
+    - What components in CockroachDB need to change? How do they change?
+
+      This section outlines the implementation strategy: for each
+      component affected, outline how it is changed.
+
+    - Are there new abstractions introduced by the change? New concepts?
+      If yes, provide definitions and examples.
+
+    - How does this work in a multi-tenant deployment?
+
+    - How does the change behave in mixed-version deployments? During a
+      version upgrade? Which migrations are needed?
+
+    - Is the result/usage of this change different for CC end-users than
+      for on-prem deployments? How?
+
+    - What are the possible interactions with other features or
+      sub-systems inside CockroachDB? How does the behavior of other code
+      change implicitly as a result of the changes outlined in the RFC?
+
+      (Provide examples if relevant.)
+
+    - Is there other ongoing or recent RFC work that is related?
+      (Cross-reference the relevant RFCs.)
+
+    - What are the edge cases? What are example uses or inputs that we
+      think are uncommon but are still possible and thus need to be
+      handled? How are these edge cases handled? Provide examples.
+
+    - What are the effect of possible mistakes by other CockroachDB team
+      members trying to use the feature in their own code? How does the
+      change impact how they will troubleshoot things?
+
+- Questions about performance:
+
+    - Does the change impact performance? How?
+
+    - If new algorithms are
+      introduced whose execution time depend on per-deployment parameters
+      (e.g. number of users, number of ranges, etc), what is their
+      high-level worst case algorithmic complexity?
+
+    - How is resource usage affected for “large” loads? For example,
+      what do we expect to happen when there are 100000 ranges? 100000
+      tables? 10000 databases? 10000 tenants? 10000 SQL users?  1000000
+      concurrent SQL queries?
+
+- Stability questions:
+
+    - Can this new functionality affect the stability of a node or the
+      entire cluster? How does the behavior of a node or a cluster degrade
+      if there is an error in the implementation?
+
+    - Can the new functionality be disabled? Can a user opt out? How?
+
+    - Can the new functionality affect clusters which are not explicitly
+      using it?
+
+    - What testing and safe guards are being put in place to
+      protect against unexpected problems?
+
+- Security questions:
+
+    - Does the change concern authentication or authorization logic? If
+      so, mention this explicitly tag the relevant security-minded
+      reviewer as reviewer to the RFC.
+
+    - Does the change create a new way to communicate data over the
+      network?  What rules are in place to ensure that this cannot be
+      used by a malicious user to extract confidential data?
+
+    - Is there telemetry or crash reporting? What mechanisms are used to
+      ensure no sensitive data is accidentally exposed?
+
+- Observability and usage questions:
+
+    - Is the change affecting asynchronous / background subsystems?
+
+        - If so, how can users and our team observe the run-time state via tracing?
+
+        - Which other inspection APIs exist?
+
+      (In general, think about how your coworkers and users will gain
+      access to the internals of the change after it has happened to
+      either gain understanding during execution or troubleshoot
+      problems.)
+
+    - Are there new APIs, or API changes (either internal or external)?
+
+        - How would you document the new APIs? Include example usage.
+
+        - What are the other components or teams that need to know about the
+          new APIs and changes?
+
+        - Which principles did you apply to ensure the APIs are consistent
+          with other related features / APIs? (Cross-reference other APIs
+          that are similar or related, for comparison.)
+
+    - Is the change visible to users of CockroachDB or operators who run CockroachDB clusters?
+
+        - Are there any user experience (UX) changes needed as a result of this RFC?
+
+        - Are the UX changes necessary or clearly beneficial? (Cross-reference the motivation section.)
+
+        - Which principles did you apply to ensure the user experience
+          (UX) is consistent with other related features?
+          (Cross-reference other CLI / GUI / SQL elements or features
+          that have related UX, for comparison.)
+
+        - Which other engineers or teams have you polled for input on the
+          proposed UX changes? Which engineers or team may have relevant
+          experience to provide feedback on UX?
+
+    - Is usage of the new feature observable in telemetry? If so,
+      mention where in the code telemetry counters or metrics would be
+      added.
+
+The section should return to the user stories in the motivations
+ection, and explain more fully how the detailed proposal makes those
+stories work.
+
+## Drawbacks
+
+Why should we *not* do this?
+
+If applicable, list mitigating factors that may make each drawback acceptable.
+
+Investigate the consequences of the proposed change onto other areas
+of CockroachDB. If other features are impacted, especially UX, list
+this impact as a reason not to do the change. If possible, also
+investigate and suggest mitigating actions that would reduce the
+impact. You can for example consider additional validation testing,
+additional documentation or doc changes, new user research, etc.
+
+Also investigate the consequences of the proposed change on
+performance. Pay especially attention to the risk that introducing a
+possible performance improvement in one area can slow down another
+area in an unexpected way. Examine all the current "consumers" of the
+code path you are proposing to change and consider whether the
+performance of any of them may be negatively impacted by the proposed
+change. List all these consequences as possible drawbacks.
+
+## Rationale and Alternatives
+
+This section is extremely important. See the
+[README](README.md#rfc-process) file for details.
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+# Explain it to someone else
+
+How do we teach this?
+
+Explain the proposal as if it was already included in the project and
+you were teaching it to an end-user, or a CockroachDB team member in a different project area.
+
+Consider the following writing prompts:
+
+- Which new concepts have been introduced to end-users? Can you
+  provide examples for each?
+
+- How would end-users change their apps or thinking to use the change?
+
+- Are there new error messages introduced? Can you provide examples?
+  If there are SQL errors, what are their 5-character SQLSTATE codes?
+
+- Are there new deprecation warnings? Can you provide examples?
+
+- How are clusters affected that were created before this change? Are
+  there migrations to consider?
+
+# Unresolved questions
+
+- What parts of the design do you expect to resolve through the RFC
+  process before this gets merged?
+
+- What parts of the design do you expect to resolve through the
+  implementation of this feature before stabilization?
+
+- What related issues do you consider out of scope for this RFC that
+  could be addressed in the future independently of the solution that
+  comes out of this RFC?

--- a/docs/rfcs/GUIDE.md
+++ b/docs/rfcs/GUIDE.md
@@ -33,7 +33,7 @@ you can spell out “this change does not affect ...” or answer “N/A”
 
 - Questions about the change:
 
-    - What components in CockroachDB need to change? How do they change?
+    - What components in Pleiades need to change? How do they change?
 
       This section outlines the implementation strategy: for each
       component affected, outline how it is changed.
@@ -46,11 +46,11 @@ you can spell out “this change does not affect ...” or answer “N/A”
     - How does the change behave in mixed-version deployments? During a
       version upgrade? Which migrations are needed?
 
-    - Is the result/usage of this change different for CC end-users than
+    - Is the result/usage of this change different for Pleiades end-users than
       for on-prem deployments? How?
 
     - What are the possible interactions with other features or
-      sub-systems inside CockroachDB? How does the behavior of other code
+      sub-systems inside Pleiades? How does the behavior of other code
       change implicitly as a result of the changes outlined in the RFC?
 
       (Provide examples if relevant.)
@@ -62,7 +62,7 @@ you can spell out “this change does not affect ...” or answer “N/A”
       think are uncommon but are still possible and thus need to be
       handled? How are these edge cases handled? Provide examples.
 
-    - What are the effect of possible mistakes by other CockroachDB team
+    - What are the effect of possible mistakes by other Pleiades team
       members trying to use the feature in their own code? How does the
       change impact how they will troubleshoot things?
 
@@ -91,7 +91,7 @@ you can spell out “this change does not affect ...” or answer “N/A”
     - Can the new functionality affect clusters which are not explicitly
       using it?
 
-    - What testing and safe guards are being put in place to
+    - What testing and safeguards are being put in place to
       protect against unexpected problems?
 
 - Security questions:
@@ -131,7 +131,7 @@ you can spell out “this change does not affect ...” or answer “N/A”
           with other related features / APIs? (Cross-reference other APIs
           that are similar or related, for comparison.)
 
-    - Is the change visible to users of CockroachDB or operators who run CockroachDB clusters?
+    - Is the change visible to users of Pleiades or operators who run Pleiades clusters?
 
         - Are there any user experience (UX) changes needed as a result of this RFC?
 
@@ -161,7 +161,7 @@ Why should we *not* do this?
 If applicable, list mitigating factors that may make each drawback acceptable.
 
 Investigate the consequences of the proposed change onto other areas
-of CockroachDB. If other features are impacted, especially UX, list
+of Pleiades. If other features are impacted, especially UX, list
 this impact as a reason not to do the change. If possible, also
 investigate and suggest mitigating actions that would reduce the
 impact. You can for example consider additional validation testing,
@@ -189,7 +189,7 @@ This section is extremely important. See the
 How do we teach this?
 
 Explain the proposal as if it was already included in the project and
-you were teaching it to an end-user, or a CockroachDB team member in a different project area.
+you were teaching it to an end-user, or a Pleiades team member in a different project area.
 
 Consider the following writing prompts:
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -34,7 +34,7 @@ signal an RFC is warranted. (Similarly, a project worthy of an RFC
 often requires multiple engineers worth of effort). Note that this
 guidance is intentionally vague. Many complex projects spread over
 multiple PRs do not require an RFC, though they do require adequate
-communication and discussion.<sup>[1](#sql-syntax)</sup>
+communication and discussion.
 
 An RFC can help you get buy-in and alignment from necessary stakeholders
 on how to best approach your project. Such alignment helps ensure that
@@ -54,7 +54,7 @@ write an RFC is a nuanced topic. When appropriate, an RFC can be a very
 effective tool. However, the process can sometimes be slow & come with a
 good amount of toil. People need time to respond, edits need to be made,
 prototypes need to be modified, and this cycle may repeat multiple times.
-Therefore, it's worth giving this question of whether or not to write an
+Therefore, it's worth giving this question of whether to write an
 RFC the proper consideration. If it is indeed appropriate, then the RFC
 process will be a great tool for strengthening the design and concepts
 behind your project.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,236 @@
+# About This Directory
+
+This directory contains RFCs (design documents) that describe proposed
+major changes to Pleiades. This process was shamelessly borrowed from
+Cockroach Labs as a starting point.
+
+# The Why of RFCs
+
+An RFC provides a high-level description of a major change or
+enhancement to Pleiades. The high-level description allows a reviewer
+to critique and poke holes in a design without getting lost in the
+particulars of code.
+
+An RFC is a form of communication aimed at both spreading and
+gathering knowledge, though it is not the sole means of accomplishing
+either task. Prototypes, tech notes, github issues, comments in code,
+commit messages and in-person discussions are valid alternatives
+depending on the situation.
+
+At its best, an RFC clearly and concisely describes the high-level
+architecture of a project giving confidence to all involved. At its
+worst, an RFC focuses on unimportant details, fosters discussion that
+stymies progress, or demoralizes the author with the complexity of
+their undertaking.
+
+# The When and How of RFCs
+
+When to write an RFC is nuanced and there are no firm rules. General
+guidance is to write an RFC before embarking on a significant or
+complex project that will be spread over multiple pull requests (PRs),
+and when multiple alternatives need to be considered and there is no
+obvious best approach. A project involving multiple people is a good
+signal an RFC is warranted. (Similarly, a project worthy of an RFC
+often requires multiple engineers worth of effort). Note that this
+guidance is intentionally vague. Many complex projects spread over
+multiple PRs do not require an RFC, though they do require adequate
+communication and discussion.<sup>[1](#sql-syntax)</sup>
+
+An RFC can help you get buy-in and alignment from necessary stakeholders
+on how to best approach your project. Such alignment helps ensure that
+by the time the team starts the implementation phase, your design &
+approach are sound & have been properly vetted.
+
+A few good questions to ask yourself before writing an RFC are:
+1. Does my project introduce new/modify existing architecture that is
+   significant to the operations of the database?
+1. Will my project have a broad impact on sensitive parts of the product,
+   where mistakes or poor design decisions could have a large negative
+   impact?
+
+If the answer to either of these questions is a resounding "yes", an RFC
+may very well be appropriate. As mentioned before, whether you should
+write an RFC is a nuanced topic. When appropriate, an RFC can be a very
+effective tool. However, the process can sometimes be slow & come with a
+good amount of toil. People need time to respond, edits need to be made,
+prototypes need to be modified, and this cycle may repeat multiple times.
+Therefore, it's worth giving this question of whether or not to write an
+RFC the proper consideration. If it is indeed appropriate, then the RFC
+process will be a great tool for strengthening the design and concepts
+behind your project.
+
+## Prototyping
+
+It is encouraged to develop a [prototype](#prototyping) concurrently
+with writing the RFC. One of the significant benefits of an RFC is
+that it forces bigger picture thinking which reviewers can then
+dissect. In contrast, a prototype forces the details to be considered,
+shedding light on the unknown unknowns and helping to ensure that the
+RFC focuses on the important design considerations.
+
+If you've never written an RFC before, consider partnering with a more
+experienced engineer for guidance and to help shepherd your RFC through
+the process.
+
+# Keep It Concise
+
+An RFC should be a high-level description which does not require
+formal correctness. There is utility in conciseness. Do not
+overspecify the details in the RFC as doing so can bury the reviewer
+in minutiae. A [prototype](#prototyping)
+can be of assistance here as it can help highlight the tricky areas
+that deserve mention in a high-level description. If the details are
+relevant, the RFC can include a link to the prototype (which may
+necessitate cleaning up some of the prototype code at the reviewer's
+request). Note that one of the significant benefits of an RFC is that
+it forces bigger picture thinking which readers can then dissect. In
+this respect an RFC is complimentary to a prototype which forces details
+to be considered.
+
+# Present a Narrative
+
+When writing your RFC, you should always keep the prospective reader
+in mind. We already mentioned above that one should do their best to
+[keep things concise](#keep-it-concise), but what more can you do to
+make the life of your reader easier?
+
+As engineers & scientists, it can be tempting to use a large pile of
+facts to state your case. After all, the facts don't lie, and if we
+present enough of them in support of our cause, it helps strengthen
+our argument. But is the reader going to enjoy reading a long laundry
+list of facts? Probably not. However, if you are able to weave these
+facts and technical designs together with a strong, singular narrative,
+your writing is more likely to resonate with the reader.
+
+Therefore, when writing your RFC, try to present your ideas with an
+overarching narrative. Be clear about the problem(s) you're trying to
+solve. Consider presenting some real-world examples to help make things
+more relatable. Do your best to structure your writing in an eloquent way.
+Taking such steps will help keep the reader engaged. This will likely
+lead to your RFC being better received and gaining more attention, which
+means you'll receive more feedback (a good thing!).
+
+# Prototyping
+
+There is a puzzle at the heart of writing an RFC: if you understand a
+project well enough to write an RFC, then an RFC may not be
+necessary. Certainly you may write an RFC to communicate your
+knowledge to others, but how does an RFC get written by an individual
+who doesn't understand the problem fully?
+
+### Iterative Writing
+
+The idealistic view of writing an RFC involves an engineer starting
+with a blank document and filling in the pieces from start to
+finish. For anyone who has written an RFC, this fairy tale depiction
+is clearly not accurate. The writing is iterative. You might first
+write down a few bullet points and then start thinking about the
+details of one area, fleshing out the document incrementally and in an
+unordered fashion. There are very likely many (many) iterations of the
+document before anyone else takes a look at it.
+
+The iterative writing of an RFC described above is often insufficient
+because simply thinking deeply about a problem is frequently not the
+most efficient path to fully understanding the problem. At the very
+least you will be consulting the existing code base to understand how
+the proposed change fits. And you might discuss the problem in front
+of a whiteboard with a colleague. It is very likely you should be
+prototyping.
+
+### The Role of Prototyping
+
+Prototyping involves exploring a problem space in order to better
+understand it. The primary value of a prototype is in the learning it
+provides, not the code. As such, the emphasis during prototyping
+should be on speed of learning. The prototype code does not need to
+meet any particular quality metric. Error handling? Ignore it while
+you're trying to learn. Comments? Only if you, the prototype author,
+need them. The real focus of the prototype is exploring the unseen
+corners of the problem space in order to reveal where the dragons are
+lurking. The goal is to de-risk the problem space by thoroughly
+understanding the hardest problems.
+
+### Write, Prototype, Repeat
+
+The acts of prototyping and writing an RFC should be iterative. Many
+engineers want to write down their thoughts before coding, and it is
+common to want to discuss an approach before embarking on it. Both
+approaches are useful, yet neither should be confused for an RFC. It
+is useful to write down a few bullet points for areas to be covered in
+a prototype. Then work on the code. Then add more bullet points. At
+some point, the prototype will be fleshed out enough that you feel
+ready to write the RFC. Alternately, it is very common for the
+prototype to run into a significant stumbling block that you can't
+overcome yourself. The benefit of the prototype truly shines when this
+happens and you'll have a deep understanding of the problem which you
+can use to have a focused discussion with other engineers. Share your
+failed prototypes. The failure implies learning and that learning
+deserves to be shared, both in words and in code. Your failed
+prototype might be close to success with the aid of another engineer's
+experience. At the very least, a failed prototype indicates to other
+engineers that an idea has been explored.
+
+### Consider if the Prototype is Sufficient
+
+Writing an RFC is not a necessary outcome for a successful
+prototype. If the prototype is simple enough, don't be afraid to translate
+it directly into a PR or series of PRs along with explanatory comments
+and commit messages.
+
+# RFC Process
+
+1. Every RFC should have a dedicated reviewer familiar with the RFC's
+   subject area.
+
+2. Copy `00000000_template.md` to a new file and fill in the
+   details. Commit this version in your own fork of the repository or
+   a branch. Your commit message (and corresponding pull request)
+   should include the prefix `rfc`. Eg: `rfc: edit RFC template`
+
+   If you are a creative person, you may prefer to start with this blank
+   slate, write your prose and then later check that all necessary topics
+   have been covered.
+
+   If you feel intimidated by a blank template, you can instead peruse
+   the list of requested topics and use the questions in there as
+   writing prompt.
+
+   The list of topics and questions that can serve as writing guide
+   can be found in the separate file [GUIDE.md](GUIDE.md).
+
+3. Submit a pull request (PR) to add your new file to the main
+   repository. Each RFC should get its own pull request; do not
+   combine RFCs with other files.
+
+   Note: you can send a PR before the RFC is complete in order to
+   solicit input about what to write in the RFC. In this case, include
+   the term "[WIP]" (work in progress) in the PR title and use the
+   label `do-not-merge`, until you are confident the RFC is complete
+   and can be reviewed.
+
+4. Go through the PR review, iterating on the RFC to answer questions
+   and concerns from the reviewer(s). The duration of this process
+   should be related to the complexity of the project. If you or the
+   reviewers seem to be at an impasse, consider in-person discussions
+   or a prototype. There is no minimum time required to leave an RFC
+   open for review. There is also no prohibition about halting or
+   reversing work on an accepted RFC if a problem is discovered during
+   implementation.
+
+   Reviewers should be conscious of their own limitations and ask for
+   other engineers to look at specific areas if necessary.
+
+5. Once discussion has settled and the RFC has received an LGTM from
+   the reviewer(s):
+
+    - change the `Status` field of the document to `in-progress`;
+    - rename the RFC document to prefix it with the current date (`YYYYMMDD_`);
+    - update the `RFC PR` field;
+    - and merge the PR.
+
+6. Once the changes in the RFC have been implemented and merged,
+   change the `Status` field of the document from `in-progress` to
+   `completed`. If subsequent developments render an RFC obsolete,
+   change its status to `obsolete`. When you mark a RFC as obsolete,
+   ensure that its text references the other RFCs or PRs that make it
+   obsolete.


### PR DESCRIPTION
This proposal recommends an internal service graph be created and introduced into the Pleiades runtime layer. This is needed because the internal app framework currently in use, fx, has reached the end of its capabilities and suitability for Pleiades. The internal service graph would be a DAG implementation in the configuration package designed to make it easy to configure, resolve, and run internal service interdependencies. The impact will affect the entire runtime layer because it will restructure and remap how service connectedness works. This implementation should allow Pleiades to start to grow its internals at different paces without breaking any isolation requirements.